### PR TITLE
Remove "metalcore" duplicate, fix #43

### DIFF
--- a/subs.yaml
+++ b/subs.yaml
@@ -91,7 +91,6 @@ Core:
   - grindcore
   - Hardcore
   - melodichardcore
-  - Metalcore
   - PostHardcore
 
 Alternative:


### PR DESCRIPTION
i figured removing it from the "Core" list was more appropriate than from the "Metal" list, since subs like "nerdcore" aren't under the "Core" heading. i could very well be wrong